### PR TITLE
Added golangci-lint work flow and Fix the remaining linting warnings

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,0 +1,21 @@
+name: golangci-lint
+on:
+  pull_request:
+    branches:
+      - main
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/setup-go@v4
+        with:
+          go-version: '1.21'
+          cache: false
+      - uses: actions/checkout@v3
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v3
+        with:
+          version: v1.54
+          args: --timeout 3m --config .golangci.yml

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,10 +1,3 @@
-# This file contains all available configuration options
-# with their default values (in comments).
-#
-# This file is not a configuration example,
-# it contains the exhaustive configuration with explanations of the options.
-
-# Options for analysis running.
 run:
   # The default concurrency value is the number of available CPU.
   concurrency: 4

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -57,7 +57,6 @@ linters:
     - unused
     - asciicheck
     - bodyclose
-    - depguard
     - dogsled
     - durationcheck
     - errname

--- a/users-api/cmd/app/app.go
+++ b/users-api/cmd/app/app.go
@@ -16,13 +16,13 @@ import (
 )
 
 func StartUsersAPI() {
-	sanityCheck()
+	// initiated logger, dependency injection, create once, inject it where needed
+	l := log.New(os.Stdout, "users-api ", log.LstdFlags)
+
+	sanityCheck(l)
 
 	gin.SetMode(gin.ReleaseMode)
 	var r = gin.New()
-
-	// initiated logger, dependency injection, create once, inject it where needed
-	l := log.New(os.Stdout, "users-api ", log.LstdFlags)
 
 	// database connection config
 	conn := database.GetMySqlDBClient()

--- a/users-api/cmd/app/app.go
+++ b/users-api/cmd/app/app.go
@@ -4,7 +4,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
-	"github.com/ashtishad/ecommerce/lib/db_connections"
+	"github.com/ashtishad/ecommerce/users-api/database"
 	"github.com/ashtishad/ecommerce/users-api/internal/domain"
 	"github.com/ashtishad/ecommerce/users-api/internal/service"
 	"github.com/ashtishad/ecommerce/users-api/pkg/ginconf"
@@ -25,7 +25,7 @@ func StartUsersAPI() {
 	l := log.New(os.Stdout, "users-api ", log.LstdFlags)
 
 	// database connection config
-	conn := db_connections.GetMySqlDBClient()
+	conn := database.GetMySqlDBClient()
 	defer func(conn *sql.DB) {
 		err := conn.Close()
 		if err != nil {

--- a/users-api/cmd/app/app_helpers.go
+++ b/users-api/cmd/app/app_helpers.go
@@ -1,14 +1,13 @@
 package app
 
 import (
-	"fmt"
 	"log"
 	"os"
 )
 
 // sanityCheck checks that all required environment variables are set.
 // if any of the required variables is not defined, it prints a log message.
-func sanityCheck() {
+func sanityCheck(l *log.Logger) {
 	envProps := []string{
 		"SERVER_ADDRESS",
 		"SERVER_PORT",
@@ -20,7 +19,7 @@ func sanityCheck() {
 	}
 	for _, k := range envProps {
 		if os.Getenv(k) == "" {
-			log.Println(fmt.Sprintf("environment variable %s not defined. Terminating application...", k))
+			l.Printf("environment variable %s not defined. Terminating application...", k)
 		}
 	}
 }

--- a/users-api/cmd/app/app_helpers.go
+++ b/users-api/cmd/app/app_helpers.go
@@ -1,10 +1,8 @@
 package app
 
 import (
-	"encoding/json"
 	"fmt"
 	"log"
-	"net/http"
 	"os"
 )
 
@@ -24,14 +22,5 @@ func sanityCheck() {
 		if os.Getenv(k) == "" {
 			log.Println(fmt.Sprintf("environment variable %s not defined. Terminating application...", k))
 		}
-	}
-}
-
-// writeResponse writes api endpoint response data and correct http status code in response.
-func writeResponse(w http.ResponseWriter, code int, data interface{}) {
-	w.Header().Add("Content-Type", "application/json")
-	w.WriteHeader(code)
-	if err := json.NewEncoder(w).Encode(data); err != nil {
-		panic(err)
 	}
 }

--- a/users-api/database/mysql_db_connection.go
+++ b/users-api/database/mysql_db_connection.go
@@ -1,4 +1,4 @@
-package db_connections
+package database
 
 import (
 	"database/sql"

--- a/users-api/internal/domain/user_repository_db.go
+++ b/users-api/internal/domain/user_repository_db.go
@@ -36,6 +36,7 @@ func (d UserRepositoryDB) Create(user User, salt string) (User, error) {
 		return User{}, err
 	}
 
+	// Why? check commit #054e1b6d4f6dcb9d988a89f83fb39fc9b50eabe4
 	defer func() {
 		if err != nil {
 			rollBackErr := tx.Rollback()

--- a/users-api/internal/domain/user_repository_db.go
+++ b/users-api/internal/domain/user_repository_db.go
@@ -135,7 +135,7 @@ func (d UserRepositoryDB) findUserByID(userID int) (User, error) {
 	err := row.Scan(&user.UserID, &user.UserUUID, &user.Email, &user.PasswordHash, &user.FullName, &user.Phone, &user.SignUpOption, &user.Status, &user.CreatedAt, &user.UpdatedAt)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			//d.l.Println(err.Error())
+			// d.l.Println(err.Error())
 			return User{}, err
 		}
 		return User{}, fmt.Errorf("error scanning user data: %v", err)
@@ -153,7 +153,7 @@ func (d UserRepositoryDB) findUserByUUID(userUUID string) (User, error) {
 	err := row.Scan(&user.UserID, &user.UserUUID, &user.Email, &user.PasswordHash, &user.FullName, &user.Phone, &user.SignUpOption, &user.Status, &user.CreatedAt, &user.UpdatedAt)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			//d.l.Println(err.Error())
+			// d.l.Println(err.Error())
 			return User{}, err
 		}
 		return User{}, fmt.Errorf("error scanning user data: %v", err)

--- a/users-api/internal/domain/user_repository_db.go
+++ b/users-api/internal/domain/user_repository_db.go
@@ -35,9 +35,11 @@ func (d UserRepositoryDB) Create(user User, salt string) (User, error) {
 	if err != nil {
 		return User{}, err
 	}
+
 	defer func() {
 		if err != nil {
-			tx.Rollback()
+			rollBackErr := tx.Rollback()
+			d.l.Printf("failed to rollback in create user %s", rollBackErr.Error())
 		}
 	}()
 

--- a/users-api/internal/service/service_helpers.go
+++ b/users-api/internal/service/service_helpers.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"github.com/ashtishad/ecommerce/users-api/internal/domain"
+	"github.com/ashtishad/ecommerce/users-api/pkg/constants"
 	"regexp"
 )
 
@@ -16,8 +17,7 @@ import (
 //   - Phone: Must consist only of digits and must be between 10 and 15 characters in length.
 //   - SignUpOption: Must be either 'general' or 'google'.
 func validateCreateUserInput(input domain.NewUserRequestDTO) error {
-	emailRegex := `^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$`
-	if matched := regexp.MustCompile(emailRegex).MatchString(input.Email); !matched {
+	if matched := regexp.MustCompile(constants.EmailRegex).MatchString(input.Email); !matched {
 		return fmt.Errorf("invalid email, you entered %s", input.Email)
 	}
 
@@ -25,17 +25,15 @@ func validateCreateUserInput(input domain.NewUserRequestDTO) error {
 		return errors.New("password must be at least 8 characters long")
 	}
 
-	fullNameRegex := `^[a-zA-Z\s]+$`
-	if matched := regexp.MustCompile(fullNameRegex).MatchString(input.FullName); !matched {
+	if matched := regexp.MustCompile(constants.FullNameRegex).MatchString(input.FullName); !matched {
 		return fmt.Errorf("full name can only contain letters and spaces, you entered : %s", input.FullName)
 	}
 
-	phoneRegex := `^\d{10,15}$`
-	if matched := regexp.MustCompile(phoneRegex).MatchString(input.Phone); !matched {
+	if matched := regexp.MustCompile(constants.PhoneRegex).MatchString(input.Phone); !matched {
 		return fmt.Errorf("phone must contain 10 to 15 digits, you entered: %s", input.Phone)
 	}
 
-	if input.SignUpOption != "general" && input.SignUpOption != "google" {
+	if input.SignUpOption != constants.SignupOptGeneral && input.SignUpOption != constants.SignUpOptGoogle {
 		return fmt.Errorf("sign up option must be 'general' or 'google': %s", input.SignUpOption)
 	}
 
@@ -51,23 +49,19 @@ func validateCreateUserInput(input domain.NewUserRequestDTO) error {
 //   - Phone: Must consist only of digits and must be between 10 and 15 characters in length.
 //   - User_id: Must be an uuid.
 func validateUpdateUserInput(input domain.UpdateUserRequestDTO) error {
-	userUUIDRegex := `^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[1-5][a-fA-F0-9]{3}-[89abAB][a-fA-F0-9]{3}-[a-fA-F0-9]{12}$`
-	if matched := regexp.MustCompile(userUUIDRegex).MatchString(input.UserUUID); !matched {
+	if matched := regexp.MustCompile(constants.UUIDRegex).MatchString(input.UserUUID); !matched {
 		return fmt.Errorf("invalid uuid, you entered %s", input.UserUUID)
 	}
 
-	emailRegex := `^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$`
-	if matched := regexp.MustCompile(emailRegex).MatchString(input.Email); !matched {
+	if matched := regexp.MustCompile(constants.EmailRegex).MatchString(input.Email); !matched {
 		return fmt.Errorf("invalid email, you entered %s", input.Email)
 	}
 
-	fullNameRegex := `^[a-zA-Z\s]+$`
-	if matched := regexp.MustCompile(fullNameRegex).MatchString(input.FullName); !matched {
+	if matched := regexp.MustCompile(constants.FullNameRegex).MatchString(input.FullName); !matched {
 		return fmt.Errorf("full name can only contain letters and spaces, you entered : %s", input.FullName)
 	}
 
-	phoneRegex := `^\d{10,15}$`
-	if matched := regexp.MustCompile(phoneRegex).MatchString(input.Phone); !matched {
+	if matched := regexp.MustCompile(constants.PhoneRegex).MatchString(input.Phone); !matched {
 		return fmt.Errorf("phone must contain 10 to 15 digits, you entered: %s", input.Phone)
 	}
 
@@ -79,8 +73,7 @@ func validateUpdateUserInput(input domain.UpdateUserRequestDTO) error {
 //     and dashes before the @ symbol.
 //   - Password: Must word must be eight characters long or more
 func validateExistingUserInput(input domain.ExistingUserRequestDTO) error {
-	emailRegex := `^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$`
-	if matched := regexp.MustCompile(emailRegex).MatchString(input.Email); !matched {
+	if matched := regexp.MustCompile(constants.EmailRegex).MatchString(input.Email); !matched {
 		return fmt.Errorf("invalid email, you entered %s", input.Email)
 	}
 

--- a/users-api/internal/service/user_service.go
+++ b/users-api/internal/service/user_service.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"github.com/ashtishad/ecommerce/users-api/internal/domain"
+	"github.com/ashtishad/ecommerce/users-api/pkg/constants"
 	"github.com/ashtishad/ecommerce/users-api/pkg/hashpassword"
 )
 
@@ -40,7 +41,7 @@ func (service DefaultUserService) NewUser(request domain.NewUserRequestDTO) (*do
 		FullName:     request.FullName,
 		Phone:        request.Phone,
 		SignUpOption: request.SignUpOption,
-		Status:       "active",
+		Status:       constants.UserStatusActive,
 	}
 
 	createdUser, err := service.repo.Create(user, salt)
@@ -72,7 +73,7 @@ func (service DefaultUserService) UpdateUser(request domain.UpdateUserRequestDTO
 		Email:    request.Email,
 		FullName: request.FullName,
 		Phone:    request.Phone,
-		Status:   "active",
+		Status:   constants.UserStatusActive,
 	}
 
 	updatedUser, err := service.repo.Update(user)

--- a/users-api/pkg/constants/constants.go
+++ b/users-api/pkg/constants/constants.go
@@ -1,0 +1,14 @@
+package constants
+
+const (
+	EmailRegex       = `^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}$`
+	FullNameRegex    = `^[a-zA-Z\s]+$`
+	PhoneRegex       = `^\d{10,15}$`
+	SignUpOptGoogle  = "google"
+	SignupOptGeneral = "general"
+	UUIDRegex        = `^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[1-5][a-fA-F0-9]{3}-[89abAB][a-fA-F0-9]{3}-[a-fA-F0-9]{12}$`
+	UserStatusActive = "active"
+
+	// UserStatusInactive = "inactive"
+	// UserStatusDeleted  = "deleted"
+)

--- a/users-api/pkg/ginconf/ginconf.go
+++ b/users-api/pkg/ginconf/ginconf.go
@@ -32,14 +32,14 @@ func GracefulShutdown(srv *http.Server) {
 // Logger implements logger util for gin
 func Logger(param gin.LogFormatterParams) string {
 	return fmt.Sprintf("[%s] | %s | %s | %d | %s |%s\n",
-		//param.ClientIP,
+		// param.ClientIP,
 		param.TimeStamp.Format("2006-01-02 15:04:05"),
 		param.Method,
 		param.Path,
-		//param.Request.Proto,
+		// param.Request.Proto,
 		param.StatusCode,
 		param.Latency,
-		//param.Request.UserAgent(),
+		// param.Request.UserAgent(),
 		param.ErrorMessage,
 	)
 }

--- a/users-api/pkg/ginconf/ginconf.go
+++ b/users-api/pkg/ginconf/ginconf.go
@@ -24,7 +24,7 @@ func GracefulShutdown(srv *http.Server) {
 	// graceful shutdown
 	log.Println("Shutting down server...")
 	if err := srv.Shutdown(ctx); err != nil {
-		log.Fatalf("Could not gracefully shutdown the server: %v\n", err)
+		log.Printf("Could not gracefully shutdown the server: %v\n", err)
 	}
 	log.Println("Server gracefully stopped")
 }

--- a/users-api/pkg/hashpassword/hashpassword.go
+++ b/users-api/pkg/hashpassword/hashpassword.go
@@ -22,9 +22,9 @@ func HashPassword(password string, saltHex string) string {
 	passwordBytes := []byte(password)
 	salt, _ := hex.DecodeString(saltHex)
 
-	passwordAndSalt := append(passwordBytes, salt...)
+	passwordBytes = append(passwordBytes, salt...)
 
-	hash := sha256.Sum256(passwordAndSalt)
+	hash := sha256.Sum256(passwordBytes)
 
 	hashedPassword := hex.EncodeToString(hash[:])
 


### PR DESCRIPTION
Configure golangci-lint workflow: https://theeloquentgo.substack.com/p/setup-golangci-lint-workflow

Fixed warnings:
* defer tx.Rollback() error handle: Instead of handling the error received from tx.RollBack(), I choose not to complicate the logic using a closure. This approach of logging the rollback error provides a balanced solution. I am not complicating the flow of my method with additional error handling, but I am still keeping track of unexpected situations.
* log.Fatalf directly calls os.Exit(), so defer statement wont be executed.
* If any variable is declared with same value thrice(like: email regex in input validation), better to make it a constant. For follow up, I made all database enums and input regex constant.